### PR TITLE
Fix crash in retrying _xcall

### DIFF
--- a/lib/magento.js
+++ b/lib/magento.js
@@ -12,14 +12,14 @@ var MagentoConnector = function(config) {
             var next = function() {
                 MagentoClient.methodCall('call', [ MagentoClient.sessionId, api, args ], function(err,res) {
                     if (err) {
-                                        // try logging in again
-                                        if (err.faultCode == 5 && MagentoClient.sessionId) {
-                                            MagentoClient.sessionId = undefined;
-                                            return this._xcall(self,api,apiargs);
-                                        }
-                                    }
-                                    callback(err,res);
-                                });
+                        // try logging in again
+                        if (err.faultCode == 5 && MagentoClient.sessionId) {
+                            MagentoClient.sessionId = undefined;
+                            return __privateMethods._xcall(self, api, apiargs);
+                        }
+                    }
+                    callback(err,res);
+                });
             }
 
             if (MagentoClient.sessionId == undefined)
@@ -27,7 +27,6 @@ var MagentoConnector = function(config) {
             else
                 next();
         },
-
 
         _call: function(self,apiargs) {
             var args = Array.prototype.slice.call(apiargs);
@@ -64,7 +63,7 @@ var MagentoConnector = function(config) {
                 self.login(next);
             else
                 next();
-        },
+        }
     }
 
     return {
@@ -113,7 +112,7 @@ var MagentoConnector = function(config) {
 
         define: function(apiname) {
             var obj = this;
-            apis = apiname.split('.');
+            var apis = apiname.split('.');
             if (obj[apis[0]] == undefined)
                 obj[apis[0]] = {};
             obj[apis[0]][apis[1]] = function() {
@@ -125,5 +124,3 @@ var MagentoConnector = function(config) {
 }
 
 module.exports = MagentoConnector;
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magentojs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Magento's connector for Node.js applications \n\n\n\n Credits to <a href='http://qzaidi.github.io/2011/10/16/magento-node/'>Alan Kay</a>",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We may be the only ones still using this library but this bug has been there for a long time. The scope on `this` in the callback refers to the global context and causes a crash in the error handling portion - in our case crashing our entire application. Would be great if this fix could be merged :)